### PR TITLE
fix: use close to xclose

### DIFF
--- a/src/core/finalize/finalize.c
+++ b/src/core/finalize/finalize.c
@@ -6,38 +6,34 @@
 /*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 15:30:10 by teando            #+#    #+#             */
-/*   Updated: 2025/04/10 20:46:03 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/04/10 22:11:51 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "core.h"
 #include "libms.h"
 
-// #include "mod_env.h"
-
 /**
- * @brief ft_lstclearに渡すdel関数
+ * @brief 環境変数特殊文字配列のメモリを解放する
  *
- * @param t_listのdata
+ * @param env_spc 環境変数特殊文字の配列
  */
-static void	clear_data(void *data)
-{
-	xfree(&data);
-	return ;
-}
-
-static void free_env_spc(char **env_spc)
+static void	free_env_spc(char **env_spc)
 {
 	size_t	i;
+	void	*temp;
 
 	i = 0;
 	while (i < 128)
 	{
 		if (env_spc[i])
-			xfree(&env_spc[i]);
+		{
+			temp = env_spc[i];
+			xfree(&temp);
+			env_spc[i] = NULL;
+		}
 		i++;
 	}
-	return ;
 }
 
 /**
@@ -50,24 +46,14 @@ void	shell_cleanup(t_shell *shell)
 	if (!shell)
 		return ;
 	line_init(shell);
-	ft_lstclear(&shell->env_map, clear_data);
+	ft_lstclear(&shell->env_map, free);
 	free_env_spc(shell->env_spc);
-	xfree(&shell->cwd);
 	if (shell->stdin_backup != -1)
-	{
-		close(shell->stdin_backup);
-		shell->stdin_backup = -1;
-	}
+		xclose(&shell->stdin_backup);
 	if (shell->stdout_backup != -1)
-	{
-		close(shell->stdout_backup);
-		shell->stdout_backup = -1;
-	}
+		xclose(&shell->stdout_backup);
 	if (shell->stderr_backup != -1)
-	{
-		close(shell->stderr_backup);
-		shell->stderr_backup = -1;
-	}
+		xclose(&shell->stderr_backup);
 }
 
 /**


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replaced `close` calls with `xclose` for better error handling.

- Updated memory cleanup logic in `free_env_spc` function.

- Simplified `ft_lstclear` usage by removing custom `clear_data`.

- Improved shell cleanup process for resource management.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>finalize.c</strong><dd><code>Improved cleanup logic and replaced `close` with `xclose`</code></dd></summary>
<hr>

src/core/finalize/finalize.c

<li>Replaced <code>close</code> calls with <code>xclose</code> for better error handling.<br> <li> Updated <code>free_env_spc</code> to ensure memory is freed and pointers are <br>nullified.<br> <li> Removed custom <code>clear_data</code> function and used <code>free</code> directly in <br><code>ft_lstclear</code>.<br> <li> Enhanced shell cleanup logic for stdin, stdout, and stderr backups.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/6/files#diff-1faba2f5da7a249356f256687313c794946dbb8ceb34bf158b4415db064d38b9">+14/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>