### PR TITLE
Fix-here-doc

### DIFF
--- a/inc/mod_sem.h
+++ b/inc/mod_sem.h
@@ -38,6 +38,9 @@ t_status						mod_sem(t_shell *shell);
 void							debug_print_sem(t_ast *ast, t_shell *sh);
 
 char							*handle_wildcard(char *in, t_shell *sh);
+int								proc_redr_errs(t_lexical_token *data,
+									t_shell *sh);
+size_t							count_aft_wc_tok(char *s);
 
 // helper
 t_quote_state					is_quote_type(int c);
@@ -47,5 +50,8 @@ int								check_qs(int c, t_sem *sem);
 t_extract						*convert_ex(char *str, t_shell *shell);
 char							*replace_with_unquoted(char *str_ptr,
 									t_shell *shell);
+
+// split_with_quote
+char							**split_with_quote(char *str, t_shell *sh);
 
 #endif

--- a/inc/ms_err.h
+++ b/inc/ms_err.h
@@ -6,7 +6,7 @@
 /*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: Invalid date        by                   #+#    #+#             */
-/*   Updated: 2025/04/23 22:41:42 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/04/23 22:46:53 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@
 # define ES_NOT_EXEC_FILE "cannot execute binary file: Exec format error"
 # define ES_TEXT_BUSY "Text file busy"
 # define ES_CMD_NOT_FOUND "minishell: %s: command not found\n"
-# define ES_AMBIGUOUS "minishell: ambiguous redirect\n"
+# define ES_AMBIGUOUS "ambiguous redirect"
 # define ES_NUMERIC "numeric argument required"
 # define ES_TOO_MANY_ARGS "too many arguments"
 # define ES_NAVI "not a valid identifier"

--- a/inc/ms_err.h
+++ b/inc/ms_err.h
@@ -6,7 +6,7 @@
 /*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: Invalid date        by                   #+#    #+#             */
-/*   Updated: 2025/04/23 15:34:55 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/04/23 22:41:42 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@
 # define ES_NOT_EXEC_FILE "cannot execute binary file: Exec format error"
 # define ES_TEXT_BUSY "Text file busy"
 # define ES_CMD_NOT_FOUND "minishell: %s: command not found\n"
-# define ES_AMBIGUOUS "ambiguous redirect"
+# define ES_AMBIGUOUS "minishell: ambiguous redirect\n"
 # define ES_NUMERIC "numeric argument required"
 # define ES_TOO_MANY_ARGS "too many arguments"
 # define ES_NAVI "not a valid identifier"

--- a/src/core/finalize/finalize.c
+++ b/src/core/finalize/finalize.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   finalize.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 15:30:10 by teando            #+#    #+#             */
-/*   Updated: 2025/04/20 12:25:58 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/23 21:54:43 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,7 @@ void	shell_cleanup(t_shell *shell)
 		xclose(&shell->stdout_backup);
 	if (shell->stderr_backup != -1)
 		xclose(&shell->stderr_backup);
+	rl_clear_history();
 }
 
 /**

--- a/src/core/signal/init_signals.c
+++ b/src/core/signal/init_signals.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   init_signals.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 15:45:12 by teando            #+#    #+#             */
-/*   Updated: 2025/04/10 23:17:23 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/24 01:33:55 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,14 +36,14 @@ static void sigint_handler(int signum)
  *
  * @param signum シグナル番号
  */
-static void sigquit_handler(int signum)
-{
-    if (signum == SIGQUIT)
-    {
-        g_signal_status = SIGQUIT;
-        rl_done = 1;
-    }
-}
+// static void sigquit_handler(int signum)
+// {
+//     if (signum == SIGQUIT)
+//     {
+//         g_signal_status = SIGQUIT;
+//         rl_done = 1;
+//     }
+// }
 
 /**
  * @brief シグナルハンドラーの初期化
@@ -61,7 +61,7 @@ int init_signals(void)
     sigemptyset(&sa_int.sa_mask);
     if (sigaction(SIGINT, &sa_int, NULL) == -1)
         return (-1);
-    sa_quit.sa_handler = sigquit_handler;
+    sa_quit.sa_handler = SIG_IGN;
     sa_quit.sa_flags = SA_RESTART;
     sigemptyset(&sa_quit.sa_mask);
     if (sigaction(SIGQUIT, &sa_quit, NULL) == -1)

--- a/src/lib/libms/ms_string/trim_valid_quotes.c
+++ b/src/lib/libms/ms_string/trim_valid_quotes.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   trim_valid_quotes.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/18 23:57:33 by teando            #+#    #+#             */
-/*   Updated: 2025/04/21 19:58:20 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/23 23:34:56 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,8 +72,8 @@ char	*trim_valid_quotes(const char *s, t_shell *sh)
 
 	i = 0;
 	j = 0;
-	quote = 0;   /* いま内側で効いているクォート種別 ('"`) */
-	prev = '\0'; /* 直前文字、エスケープ判定用            */
+	quote = 0;
+	prev = '\0';
 	if (!s)
 		return (ms_strdup("", sh));
 	out = xmalloc(ft_strlen(s) + 1, sh);

--- a/src/modules/analyze_semantic/semantic.c
+++ b/src/modules/analyze_semantic/semantic.c
@@ -6,7 +6,7 @@
 /*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 10:11:39 by teando            #+#    #+#             */
-/*   Updated: 2025/04/23 19:25:09 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/04/23 23:36:33 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -152,6 +152,7 @@ static char	*prepare_delimiter(char *delim_raw, int *quoted, t_shell *sh)
 
 	*quoted = is_quoted(delim_raw);
 	delim = trim_valid_quotes(delim_raw, sh);
+	xfree((void **)&delim_raw);
 	return (delim);
 }
 
@@ -219,6 +220,7 @@ static int	handle_heredoc(t_lexical_token *tok, t_shell *sh)
 	body = read_heredoc_body(delim, quoted, sh);
 	if (!body)
 		body = ms_strdup("", sh);
+	xfree((void **)&delim);
 	tok->value = body;
 	tok->type = TT_REDIR_IN;
 	return (0);

--- a/src/modules/analyze_semantic/split_with_quote.c
+++ b/src/modules/analyze_semantic/split_with_quote.c
@@ -1,0 +1,115 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   split_with_quote.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/24 02:27:41 by tomsato           #+#    #+#             */
+/*   Updated: 2025/04/24 02:30:26 by tomsato          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "mod_sem.h"
+
+/**
+ * @brief 次のトークンの開始位置と長さを取得する
+ *
+ * @param p 探索開始位置
+ * @param start トークン開始位置へのポインタ（結果格納用）
+ * @return size_t トークンの長さ、トークンがなければ0
+ */
+static size_t	get_next_token(char **p, char **start)
+{
+	char	q;
+	char	*pos;
+
+	pos = *p;
+	while (*pos && isspace((unsigned char)*pos))
+		pos++;
+	if (!*pos)
+		return (0);
+	*start = pos;
+	if (*pos == '"' || *pos == '\'')
+	{
+		q = *pos++;
+		while (*pos && *pos != q)
+			pos++;
+		if (*pos == q)
+			pos++;
+	}
+	else
+	{
+		while (*pos && !isspace((unsigned char)*pos) && *pos != '"'
+			&& *pos != '\'')
+			pos++;
+	}
+	*p = pos;
+	return (pos - *start);
+}
+
+/**
+ * @brief メモリエラー時に確保した配列とその要素を解放する
+ *
+ * @param result 解放する文字列配列
+ * @param count 解放する要素数
+ */
+static void	free_split_result(char **result, size_t count)
+{
+	size_t	i;
+
+	if (!result)
+		return ;
+	i = 0;
+	while (i < count)
+	{
+		xfree((void **)&result[i]);
+		i++;
+	}
+	xfree((void **)&result);
+}
+
+/**
+ * @brief 文字列をクォートを考慮して分割する
+ *
+ * - 空白（スペース・タブ・改行など）で区切る
+ * - シングルクォート(')またはダブルクォート(")で囲まれた部分は、
+ *   中の空白を含めて１トークンとして扱う
+ *
+ * @param str 分割する文字列
+ * @param sh シェル情報
+ * @return char** 分割された文字列の配列（NULLで終端）
+ */
+char	**split_with_quote(char *str, t_shell *sh)
+{
+	char	**result;
+	size_t	count;
+	size_t	i;
+	char	*p;
+	char	*token_start;
+	size_t	token_len;
+
+	if (!str)
+		return (NULL);
+	count = count_aft_wc_tok(str);
+	result = xmalloc(sizeof(char *) * (count + 1), sh);
+	if (!result)
+		return (NULL);
+	p = str;
+	i = 0;
+	while (i < count)
+	{
+		token_len = get_next_token(&p, &token_start);
+		if (token_len == 0)
+			break ;
+		result[i] = ms_substr(token_start, 0, token_len, sh);
+		if (!result[i])
+		{
+			free_split_result(result, i);
+			return (NULL);
+		}
+		i++;
+	}
+	result[i] = NULL;
+	return (result);
+}

--- a/src/modules/executer/mod_exec.c
+++ b/src/modules/executer/mod_exec.c
@@ -6,7 +6,7 @@
 /*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/18 22:33:11 by teando            #+#    #+#             */
-/*   Updated: 2025/04/23 19:22:35 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/04/24 02:00:59 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,10 +78,12 @@ int	exe_run(t_ast *node, t_shell *sh)
 static int	prepare_cmd_args(t_ast *node, char ***argv, int *flag, t_shell *sh)
 {
 	struct stat	sb;
+	t_status status;
 
 	*flag = 0;
-	if (handle_redr(node->args, sh))
-		return (1);
+	status = handle_redr(node->args, sh);
+	if (status)
+		return (status);
 	*argv = toklist_to_argv(node->args->argv, sh);
 	if (!*argv)
 	{
@@ -258,10 +260,8 @@ int	exe_bool(t_ast *node, t_shell *sh)
 	int	run_right;
 
 	if (sh->env_updated)
-	{
 		mod_sem(sh);
-		sh->env_updated = 0;
-	}
+	sh->env_updated = 0;
 	st_left = exe_run(node->left, sh);
 	update_shell_status(st_left, sh);
 	run_right = 0;
@@ -273,7 +273,8 @@ int	exe_bool(t_ast *node, t_shell *sh)
 		run_right = 1;
 	if (run_right)
 	{
-		mod_sem(sh);
+		if (sh->env_updated)
+			mod_sem(sh);
 		sh->env_updated = 0;
 		return (exe_run(node->right, sh));
 	}
@@ -384,6 +385,9 @@ int	handle_redr(t_args *args, t_shell *sh)
 	while (lst)
 	{
 		tok = lst->data;
+		result = proc_redr_errs(tok, sh);
+		if (result)
+			return (result);
 		if (tok->type == TT_REDIR_IN)
 			result = handle_input_redirection(tok, args, sh);
 		else if (tok->type == TT_REDIR_OUT)

--- a/src/modules/executer/mod_exec.c
+++ b/src/modules/executer/mod_exec.c
@@ -6,7 +6,7 @@
 /*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/18 22:33:11 by teando            #+#    #+#             */
-/*   Updated: 2025/04/23 16:53:22 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/04/23 19:22:35 by tomsato          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -312,17 +312,14 @@ int	heredoc_into_fd(char *body, t_args *args, t_shell *sh)
 
 	if (xpipe(hd, sh))
 		return (1);
-	/* write() は短い本文なら一括送信で十分。失敗時はシェルごと死ぬ想定。*/
 	if (write(hd[1], body, ft_strlen(body)) == -1 || close(hd[1]) == -1)
 	{
-		perror("heredoc write");
 		close(hd[0]);
 		return (1);
 	}
-	/* 直近の < や << が勝つ POSIX 仕様を踏襲。 */
 	if (args->fds[0] > 2)
 		xclose(&args->fds[0]);
-	args->fds[0] = hd[0]; /* read end を stdin 置換候補に */
+	args->fds[0] = hd[0];
 	return (0);
 }
 
@@ -337,6 +334,14 @@ static int	handle_input_redirection(t_lexical_token *tok, t_args *args,
 	{
 		if (heredoc_into_fd(tok->value, args, sh))
 			return (1);
+	}
+	else if (tok->value && tok->value[0] == '\0')
+	{
+		if (args->fds[0] > 2)
+			xclose(&args->fds[0]);
+		args->fds[0] = open("/dev/null", O_RDONLY);
+		if (args->fds[0] == -1)
+			return (perror("/dev/null"), 1);
 	}
 	else
 	{


### PR DESCRIPTION
### **User description**
heredoc関連の動作を改善

・here_docが何度も呼び出されないように修正
・here_docの環境変数も更新されるように修正
・ctrl dでhere_docを修了した時の処理も追加。
・クォートが付いていた時の動作も少し修正。
・デリミタを展開しないように変更。
・ctrl \を押した時の動作を再現
・here_docの入力が空っぽの時に/dev/nullを見に行くように変更
・トークンが意図しない方法で分割されるのを修正
・リダイレクトの環境変数のエラー処理が実行の直前で行われるように変更


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Major overhaul of heredoc handling and related redirection logic
  - Prevents multiple heredoc invocations and improves delimiter/quote handling
  - Handles empty heredoc by redirecting to /dev/null
  - Adds warning/error messages for Ctrl-D and ambiguous redirects
  - Ensures heredoc environment variable expansion and signal handling

- Refines signal handling for SIGQUIT (Ctrl-\) to ignore the signal

- Clears readline history during shell cleanup

- Improves error handling and memory management in redirection processing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ms_err.h</strong><dd><code>Update file header metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inc/ms_err.h

- Updated file header metadata (author, timestamp).


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/40/files#diff-b3d422e651c95b33e6c4504dc8061202e9d9ac314bcf8a8d207f208b15e22ca9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>finalize.c</strong><dd><code>Clear readline history during shell cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/finalize/finalize.c

<li>Added call to rl_clear_history() in shell_cleanup to clear readline <br>history.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/40/files#diff-1faba2f5da7a249356f256687313c794946dbb8ceb34bf158b4415db064d38b9">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>init_signals.c</strong><dd><code>Ignore SIGQUIT (Ctrl-\) signal in shell</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/signal/init_signals.c

<li>Changed SIGQUIT handler to ignore the signal instead of custom <br>handler.<br> <li> Updated file header metadata.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/40/files#diff-924087af2cf16f734ae2e2e11c4c10b877c47f1d33f4079b8d4013f9efe9fb3a">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>trim_valid_quotes.c</strong><dd><code>Minor cleanup in quote handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/libms/ms_string/trim_valid_quotes.c

<li>Minor code cleanup for quote/escape variable initialization.<br> <li> Updated file header metadata.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/40/files#diff-3e7f6fda1db16b0e0987394e1e80cc097fea88b534f7f14a00c8507b8054dd15">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic.c</strong><dd><code>Major improvements to heredoc and redirection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/analyze_semantic/semantic.c

<li>Overhauled heredoc and redirection processing:<br>   - Improved <br>delimiter/quote/environment variable handling in heredoc.<br>   - Added <br>warning for Ctrl-D (EOF) in heredoc input.<br>   - Ensured empty heredoc <br>redirects to /dev/null.<br>   - Enhanced ambiguous redirect error <br>handling.<br>   - Processes all heredocs before backup of AST node args.<br> <li> Refactored code for clarity and robustness.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/40/files#diff-7aa4bcbd4e215716229a4e2b69b717a98a444d66f5329b40f0836f01c9953b3f">+49/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod_exec.c</strong><dd><code>Refine heredoc and input redirection file handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/executer/mod_exec.c

<li>Enhanced heredoc file descriptor handling:<br>   - Writes heredoc body to <br>pipe, closes properly.<br>   - Redirects empty heredoc to /dev/null.<br> <li> Improved error handling for input redirection.<br> <li> Updated file header metadata.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/40/files#diff-e9f9e1ccdac84ea4cef17473331d8da112eac9a2b7ddfad9779a5e53fd997599">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>