### PR TITLE
fix: Support for no-value behavior.

### DIFF
--- a/src/builtin_cmds/export.c
+++ b/src/builtin_cmds/export.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 23:11:41 by teando            #+#    #+#             */
-/*   Updated: 2025/04/22 17:01:16 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/28 18:58:19 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,7 @@ t_status	__export(int argc, char **argv, t_shell *sh)
 	i = 0;
 	while (++i < argc)
 	{
-		if (ms_setenv(ft_strdup(argv[i]), sh) != E_NONE)
+		if (ms_setenv(ms_strdup(argv[i], sh), sh) != E_NONE)
 			return (1);
 		sh->env_updated = 1;
 	}

--- a/src/lib/libms/ms_env/ms_setenv.c
+++ b/src/lib/libms/ms_env/ms_setenv.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 22:13:52 by teando            #+#    #+#             */
-/*   Updated: 2025/04/22 10:05:06 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/28 19:33:29 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,11 +44,15 @@ static char	*ms_handle_append_env(const char *key, const char *arg,
 static char	*ms_handle_normal_env(const char *key, const char *arg,
 		size_t eq_pos, t_shell *sh)
 {
+	t_list	*lst;
 	char	*value;
 	char	*new_entry;
 
 	if (eq_pos == 0)
 	{
+		lst = ft_list_find(sh->env_map, (void *)key, ms_envcmp);
+		if (lst && ft_strchr(lst->data, '='))
+			return (ms_strdup(lst->data, sh));
 		return (ms_strdup(key, sh));
 	}
 	else if (arg[eq_pos] == '\0')


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix handling of export with no-value arguments

- Ensure correct duplication of environment variables

- Improve compatibility with shell environment updates


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.c</strong><dd><code>Use ms_strdup for argument duplication in export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/builtin_cmds/export.c

<li>Replaced ft_strdup with ms_strdup for argument duplication in export<br> <li> Ensures correct memory management and shell context usage


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/48/files#diff-7cd6b737277f421648964598ade1d96c7bfadf88203dc204563cede944709e1f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ms_setenv.c</strong><dd><code>Fix and improve no-value export behavior in ms_setenv</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/libms/ms_env/ms_setenv.c

<li>Enhanced ms_handle_normal_env to handle no-value exports correctly<br> <li> Checks for existing environment variable and duplicates it if needed<br> <li> Uses ms_strdup for consistent memory management


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/48/files#diff-2d367efa25aaffa3c3310f43773c8f3d6db4d15de49cc2283ae30bd882d4c036">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>