### PR TITLE
fix: Do not adapt shift_or_true

### DIFF
--- a/src/modules/analyze_semantic/env_expand/proc_env.c
+++ b/src/modules/analyze_semantic/env_expand/proc_env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   proc_env.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tomsato <tomsato@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/25 21:12:11 by teando            #+#    #+#             */
-/*   Updated: 2025/04/27 21:26:07 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/04/28 20:35:46 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,7 +116,10 @@ t_status	proc_env(t_list **list, int idx, t_shell *sh)
 	token = (t_lexical_token *)(*list)->data;
 	if (!token || !token->value)
 		return (E_SYSTEM);
-	expanded_value = shift_or_true(list, token, idx, sh);
+	if (token->type == TT_HEREDOC)
+		expanded_value = ms_strdup(handle_env(token->value, sh), sh);
+	else
+		expanded_value = shift_or_true(list, token, idx, sh);
 	if (!expanded_value)
 		return (E_SYSTEM);
 	xfree((void **)&token->value);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix environment variable expansion for heredoc tokens

- Bypass `shift_or_true` for tokens of type `TT_HEREDOC`

- Use direct environment handling for heredoc token values


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proc_env.c</strong><dd><code>Fix heredoc-specific environment expansion in `proc_env`</code>&nbsp; </dd></summary>
<hr>

src/modules/analyze_semantic/env_expand/proc_env.c

<li>Updated author and timestamp in file header<br> <li> Modified <code>proc_env</code> to handle <code>TT_HEREDOC</code> tokens differently<br> <li> Bypass <code>shift_or_true</code> for heredoc, use direct environment expansion


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/50/files#diff-c729fb5f954c3db16465c7ee3459fbaa7fe2563c21e69436e9ef06f93d5e2f9a">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>