### PR TITLE
Norm fix lex

### DIFF
--- a/inc/ms_err.h
+++ b/inc/ms_err.h
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 03:24:35 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 03:33:15 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:12:18 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,6 +51,7 @@
 # define ES_BROKEN_PIPE "Broken pipe"
 # define ES_EVENT_NOT_FOUND "event not found"
 # define ES_WRITE_BROKEN_PIPE "write error: Broken pipe"
+# define ES_WHD "minishell: warning: here-document delimited by end-of-file\n"
 # define ES_INVALID_OPTION "minishell: cd: %s: invalid option\n"
 
 /*

--- a/inc/ms_readline.h
+++ b/inc/ms_readline.h
@@ -6,16 +6,16 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/21 21:07:23 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 03:21:28 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:06:48 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MS_READLINE_H
 # define MS_READLINE_H
 
+# include <stdio.h>
 # include <readline/history.h>
 # include <readline/readline.h>
-# include <stdio.h>
 
 char	*launch_readline(const char *prompt);
 char	*read_command_line(const char *prompt);

--- a/src/core/debug/init_sh_proc.c
+++ b/src/core/debug/init_sh_proc.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 13:24:52 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 03:17:38 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:03:28 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ static char	*put_debug_mode(t_shell *sh)
 		return ("ENV");
 	else if (sh->debug == DEBUG_EXEC)
 		return ("EXEC");
-	else if (sh->debug == DEBUG_REDIRECT)
+	else if (sh->debug == DEBUG_REDR)
 		return ("REDIRECT");
 	else if (sh->debug == DEBUG_SIGNAL)
 		return ("SIGNAL");

--- a/src/modules/analyze_lexical/heredoc_loop.c
+++ b/src/modules/analyze_lexical/heredoc_loop.c
@@ -1,4 +1,4 @@
-/* ************************************************************************** */
+/******************************************************************************/
 /*                                                                            */
 /*                                                        :::      ::::::::   */
 /*   heredoc_loop.c                                     :+:      :+:    :+:   */
@@ -6,9 +6,9 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 17:08:24 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 01:52:02 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:02:55 by teando           ###   ########.fr       */
 /*                                                                            */
-/* ************************************************************************** */
+/******************************************************************************/
 
 #include "mod_lex.h"
 
@@ -28,20 +28,19 @@ static char	*read_heredoc_body(char *delim, t_shell *sh)
 	while (42)
 	{
 		line = read_command_line("> ");
-		if (!line || (delim[0] == '\0' && line[0] == '\0') || !ft_strcmp(line,
-				delim))
+		if (!line || (!delim[0] && !line[0]) || !ft_strcmp(line, delim))
 		{
 			if (!line && g_signal_status != SIGINT)
-				ft_dprintf(STDERR_FILENO, ES_HEREDOC, delim);
+				ft_dprintf(2,
+					"minishell: warning: here-document delimited by end-of-file (wanted `%s')\n",
+					delim);
 			if (line)
 				xfree((void **)&line);
 			break ;
 		}
 		if (g_signal_status == SIGINT)
-		{
-			sh->status = E_SIGINT;
-			return (xfree((void **)&body), xfree((void **)&line), NULL);
-		}
+			return (sh->status = E_SIGINT, xfree((void **)&body),
+				xfree((void **)&line), NULL);
 		body = xstrjoin_free2(body, line, sh);
 		body = xstrjoin_free(body, "\n", sh);
 	}

--- a/src/modules/analyze_lexical/heredoc_loop.c
+++ b/src/modules/analyze_lexical/heredoc_loop.c
@@ -1,4 +1,4 @@
-/******************************************************************************/
+/* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
 /*   heredoc_loop.c                                     :+:      :+:    :+:   */
@@ -6,9 +6,9 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 17:08:24 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 12:02:55 by teando           ###   ########.fr       */
+/*   Updated: 2025/04/29 12:13:17 by teando           ###   ########.fr       */
 /*                                                                            */
-/******************************************************************************/
+/* ************************************************************************** */
 
 #include "mod_lex.h"
 
@@ -31,16 +31,16 @@ static char	*read_heredoc_body(char *delim, t_shell *sh)
 		if (!line || (!delim[0] && !line[0]) || !ft_strcmp(line, delim))
 		{
 			if (!line && g_signal_status != SIGINT)
-				ft_dprintf(2,
-					"minishell: warning: here-document delimited by end-of-file (wanted `%s')\n",
-					delim);
+				ft_dprintf(STDERR_FILENO, ES_WHD);
 			if (line)
 				xfree((void **)&line);
 			break ;
 		}
 		if (g_signal_status == SIGINT)
-			return (sh->status = E_SIGINT, xfree((void **)&body),
-				xfree((void **)&line), NULL);
+		{
+			sh->status = E_SIGINT;
+			return (xfree((void **)&body), xfree((void **)&line), NULL);
+		}
 		body = xstrjoin_free2(body, line, sh);
 		body = xstrjoin_free(body, "\n", sh);
 	}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix incorrect debug mode constant in `init_sh_proc.c`

- Correct heredoc warning message and macro usage

- Update error message macro definitions for heredoc warnings

- Adjust header include order in `ms_readline.h`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ms_err.h</strong><dd><code>Add heredoc EOF warning macro definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inc/ms_err.h

<li>Added new macro <code>ES_WHD</code> for heredoc EOF warning message<br> <li> Updated file header timestamp


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/56/files#diff-b3d422e651c95b33e6c4504dc8061202e9d9ac314bcf8a8d207f208b15e22ca9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ms_readline.h</strong><dd><code>Adjust header include order for stdio and readline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inc/ms_readline.h

<li>Moved <code>#include <stdio.h></code> before readline headers<br> <li> Updated file header timestamp


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/56/files#diff-44f2512b1d1f6f0af9ccc7c69abfa87b59be29ac19169b0b1cf44b7d90395a8e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>init_sh_proc.c</strong><dd><code>Fix debug mode constant for redirect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/debug/init_sh_proc.c

<li>Fixed debug mode constant from <code>DEBUG_REDIRECT</code> to <code>DEBUG_REDR</code><br> <li> Updated file header timestamp


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/56/files#diff-8c43846fc1f6f3b59a9b590ed4001b4847af519a3d6e413cdda9d59fc8adebec">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heredoc_loop.c</strong><dd><code>Fix heredoc warning macro and delimiter check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/analyze_lexical/heredoc_loop.c

<li>Changed heredoc warning macro from <code>ES_HEREDOC</code> to <code>ES_WHD</code><br> <li> Simplified delimiter check in heredoc loop<br> <li> Updated file header timestamp


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/56/files#diff-2328302bf1cb4c138294eff21c41fe681b9f4f5dc19f002cc91d52f76d8b4616">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>