### PR TITLE
Hotfix 0503

### DIFF
--- a/src/builtin_cmds/unset.c
+++ b/src/builtin_cmds/unset.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/18 22:44:20 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 20:03:24 by teando           ###   ########.fr       */
+/*   Updated: 2025/05/03 15:49:10 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ t_status	__unset(int argc, char **argv, t_shell *sh)
 	(void)argv;
 	(void)sh;
 	if (argc == 1)
-		return (ft_dprintf(2, "minishell: unset: missing operand\n"), 1);
+		return (E_NONE);
 	i = 0;
 	while (++i < argc)
 	{

--- a/src/modules/executer/exec_cmd.c
+++ b/src/modules/executer/exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 22:43:40 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 01:39:31 by teando           ###   ########.fr       */
+/*   Updated: 2025/05/03 15:54:37 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,10 @@ static int	prepare_argv(t_ast *node, char ***out, int *flag, t_shell *sh)
 	struct stat	sb;
 
 	if (handle_redr(node->args, sh))
+	{
+		*flag = 1;
 		return (E_SYSTEM);
+	}
 	*out = toklist_to_argv(node->args->argv, sh);
 	if (!*out)
 	{

--- a/src/modules/executer/exec_pipe.c
+++ b/src/modules/executer/exec_pipe.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 22:44:30 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 22:08:00 by teando           ###   ########.fr       */
+/*   Updated: 2025/05/03 15:49:59 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ static pid_t	execute_left_pipe(t_ast *node, int fds[2], t_shell *sh)
 	lpid = xfork(sh);
 	if (lpid == 0)
 	{
+		sh->interactive = 0;
 		xdup2(&fds[1], STDOUT_FILENO, sh);
 		xclose(&fds[0]);
 		xclose(&fds[1]);
@@ -41,6 +42,7 @@ static pid_t	execute_right_pipe(t_ast *node, int fds[2], t_shell *sh)
 	rpid = xfork(sh);
 	if (rpid == 0)
 	{
+		sh->interactive = 0;
 		xdup2(&fds[0], STDIN_FILENO, sh);
 		xclose(&fds[0]);
 		xclose(&fds[1]);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes error handling in the `unset` builtin for missing operands.

- Ensures error flag is set when `handle_redr` fails in command execution.

- Sets shell to non-interactive mode in both sides of pipe execution.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unset.c</strong><dd><code>Fix unset to not error on missing operand</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/builtin_cmds/unset.c

<li>Changed <code>unset</code> to return <code>E_NONE</code> instead of error when no operand is <br>given.<br> <li> Removes error message output for missing operand.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/65/files#diff-c489854d8cb5e1fcba2f739cdfd6cc722b599f32ccfbf1227db81214ebf55039">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exec_cmd.c</strong><dd><code>Set error flag on handle_redr failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/executer/exec_cmd.c

<li>Sets error flag when <code>handle_redr</code> fails during command preparation.<br> <li> Ensures error code is returned appropriately.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/65/files#diff-154f30ba87db317fc8f052b5d92c4f05c4d8394328d64c78412f9f8c559a5202">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exec_pipe.c</strong><dd><code>Set non-interactive mode in pipe child processes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/executer/exec_pipe.c

<li>Sets <code>sh->interactive</code> to 0 in both left and right pipe child processes.<br> <li> Ensures correct shell mode during piped command execution.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/65/files#diff-3468f85979944e51dc46c4de077aa524b2f237ce4a88f4f99871708d375193aa">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>