### PR TITLE
fix: env expr and debug and . err

### DIFF
--- a/inc/ms_err.h
+++ b/inc/ms_err.h
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 03:24:35 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 12:12:18 by teando           ###   ########.fr       */
+/*   Updated: 2025/05/10 16:07:36 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,7 @@
 # define ES_AMBIGUOUS "minishell: %s: ambiguous redirect\n"
 # define ES_NUMERIC "numeric argument required"
 # define ES_TOO_MANY_ARGS "minishell: %s: too many arguments\n"
+# define ES_DOT "minishell: .: filename argument required\n.: usage: . filename [arguments]\n"
 # define ES_NAVI "not a valid identifier"
 # define ES_SHIFT_RANGE "shift count out of range"
 # define ES_BAD_SUBSTITUTION "bad substitution"

--- a/src/lib/libms/ms_path/path_resolve.c
+++ b/src/lib/libms/ms_path/path_resolve.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/13 22:18:40 by teando            #+#    #+#             */
-/*   Updated: 2025/04/29 03:09:20 by teando           ###   ########.fr       */
+/*   Updated: 2025/05/10 16:21:01 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,15 +33,15 @@ static int	check(int *c, char *in, t_shell *sh)
 	struct stat	st;
 
 	(void)sh;
-	if (is_builtin(in))
-	{
-		*c = 0;
-		return (1);
-	}
-	else if (ft_strcmp(in, "\0") == 0)
+	if (ft_strcmp(in, "\0") == 0)
 	{
 		*c = E_COMMAND_NOT_FOUND;
 		return (ft_dprintf(2, ES_CMD_NOT_FOUND, "''"), 1);
+	}
+	if (ft_strcmp(in, ".") == 0)
+	{
+		*c = E_NUMERIC;
+		return (ft_dprintf(2, ES_DOT), 1);
 	}
 	if (stat(in, &st) == 0)
 	{
@@ -63,7 +63,8 @@ int	path_resolve(char **in, t_shell *sh)
 	size_t	i;
 	int		c;
 
-	if (check(&c, *in, sh))
+	c = 0;
+	if (is_builtin(*in) || check(&c, *in, sh))
 		return (c);
 	paths = xsplit(ms_getenv("PATH", sh), ':', sh);
 	if (!paths || !paths[0])

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/10 19:12:00 by teando            #+#    #+#             */
-/*   Updated: 2025/05/10 15:15:57 by teando           ###   ########.fr       */
+/*   Updated: 2025/05/10 16:17:21 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,7 @@ int	main(int ac, char **av, char **env)
 		return (ft_dprintf(2, "signal setup failure\n"), E_SYSTEM);
 	set_cloexec_all();
 	sh = shell_init(env, av[0]);
-	if (sh->debug & DEBUG_NO_PROMPT)
+	if (sh->debug & DEBUG_NO_PROMPT && !(sh->debug & DEBUG_CORE))
 		shell_loop(sh, "");
 	else
 		shell_loop(sh, PROMPT);

--- a/src/modules/analyze_semantic/env_expand/proc_env.c
+++ b/src/modules/analyze_semantic/env_expand/proc_env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   proc_env.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tomsato <tomsato@student.42.jp>            +#+  +:+       +#+        */
+/*   By: teando <teando@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/25 21:12:11 by teando            #+#    #+#             */
-/*   Updated: 2025/05/10 14:14:23 by tomsato          ###   ########.fr       */
+/*   Updated: 2025/05/10 16:35:46 by teando           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,6 +42,8 @@ static size_t	extract_varname(char **buf, char *in, t_shell *sh)
 		val = ms_strdup_gcli("", sh);
 	ft_gc_track(sh->gcli, val);
 	*buf = ms_strjoin_gcli(*buf, val, sh);
+	if (ft_strchr(" \t\n\r\f", (*buf)[0]))
+		*buf = ms_strjoin3_gcli("\'", *buf, "\'", sh);
 	return (klen);
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed environment variable expansion to quote leading whitespace values.

- Improved error handling for `.` command with missing arguments.

- Adjusted debug prompt logic for better control in debug modes.

- Refined command resolution to handle builtins and empty input correctly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ms_err.h</strong><dd><code>Add error message for dot command usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inc/ms_err.h

- Added new error message macro for `.` command usage error.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/75/files#diff-b3d422e651c95b33e6c4504dc8061202e9d9ac314bcf8a8d207f208b15e22ca9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>minishell.c</strong><dd><code>Adjust debug prompt suppression logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/minishell.c

<li>Modified debug prompt logic to only suppress prompt if not in core <br>debug mode.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/75/files#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>path_resolve.c</strong><dd><code>Refine command resolution and dot error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/libms/ms_path/path_resolve.c

<li>Changed command resolution to check for builtins after empty input and <br>dot command checks.<br> <li> Added error handling for <code>.</code> command with missing filename.<br> <li> Refined order of checks for command input.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/75/files#diff-0b95543deef96774715fd42e534905293e5d2fbd5c93ed0e249830e93fb148f5">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proc_env.c</strong><dd><code>Quote env values with leading whitespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/analyze_semantic/env_expand/proc_env.c

<li>Added logic to quote environment variable values that start with <br>whitespace.<br> <li> Ensured correct handling of whitespace in expanded environment <br>variables.


</details>


  </td>
  <td><a href="https://github.com/TetsuroAndo/42-minishell_v2/pull/75/files#diff-c729fb5f954c3db16465c7ee3459fbaa7fe2563c21e69436e9ef06f93d5e2f9a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>